### PR TITLE
Lai's Astral balancing

### DIFF
--- a/.minecraft/config/astralsorcery.cfg
+++ b/.minecraft/config/astralsorcery.cfg
@@ -195,8 +195,8 @@ general {
 
     # Whitelist of dimension ID's that will have special sky rendering [default: [0]]
     S:skySupportedDimensions <
-        0
-        24
+	0
+	24
      >
 
     # Defines how much the 'sharpened' modifier increases the damage of the sword if applied. Config value is in percent. [range: 0.0 ~ 10000.0, default: 0.1]
@@ -204,8 +204,8 @@ general {
 
     # IF a dimensionId is listed in 'skySupportedDimensions' you can add it here to keep its sky render, but AS will try to render only constellations on top of its existing sky render. [default: ]
     S:weakSkyRenders <
-        0
-        24
+	0
+	24
      >
 
     shooting_stars {
@@ -303,7 +303,7 @@ perk_levels {
 
     level {
         # Sets the max level for the perk tree levels. [range: 1 ~ 100, default: 30]
-        I:levelCap=30
+        I:levelCap=50
     }
 
 }
@@ -322,16 +322,16 @@ perks {
         B:gemAllowNegativeModifier=false
 
         # Defines the chance the gem can roll a 3rd modifier. The lower this chance, the rarer. [range: 0.0 ~ 1.0, default: 0.2]
-        S:gemChance3Modifiers=0.2
+        S:gemChance3Modifiers=0.5
 
         # Defines the chance the gem can roll a 4th modifier. A 3rd modifier MUST be rolled before and the chances are independent of each other. The lower this chance, the rarer. [range: 0.0 ~ 1.0, default: 0.05]
-        S:gemChance4Modifiers=0.05
+        S:gemChance4Modifiers=0.2
 
         # If 'AllowMoreLessModifier' is set to true, this defines the chance a given modifier may be 'more'/'less' instead of 'increased'/'decreased'. [range: 0.0 ~ 1.0, default: 0.1]
         S:gemChanceMoreLessModifier=0.1
 
         # If 'AllowNegativeModifier' is set to true, this defines the chance a given modifier may be negative instead of positive. [range: 0.0 ~ 1.0, default: 0.25]
-        S:gemChanceNegativeModifier=0.25
+        S:gemChanceNegativeModifier=0
 
         # List of weighted modifiers the gem may roll. Format: 'modifier=weight' [default: [astralsorcery.attackspeed=2], [astralsorcery.expgain=1], [astralsorcery.armor=8], [astralsorcery.projectileattackdamage=8], [astralsorcery.dodge=2], [astralsorcery.movespeed=8], [astralsorcery.critchance=4], [astralsorcery.reach=4], [astralsorcery.meleeattackdamage=8], [astralsorcery.allres=2], [astralsorcery.compat.thaumcraft.runicshield=2], [astralsorcery.critmulti=4], [astralsorcery.maxhealth=12], [astralsorcery.liferecovery=2], [astralsorcery.harvestspeed=2]]
         S:gemWeightedModifiers <
@@ -360,10 +360,10 @@ perks {
             S:Decreased_Lower_Bound=0.05
 
             # Defines the lower bound an 'increased' modifier can roll. Value is in percent (0.01 means 1%, 0.1 means 10%, ...) [range: 0.0 ~ 1.0, default: 0.08]
-            S:Increased_Higher_Bound=0.08
+            S:Increased_Higher_Bound=0.1
 
             # Defines the lower bound an 'increased' modifier can roll. Value is in percent (0.01 means 1%, 0.1 means 10%, ...) [range: 0.0 ~ 1.0, default: 0.05]
-            S:Increased_Lower_Bound=0.05
+            S:Increased_Lower_Bound=0.08
 
             # Defines the lower bound an 'less' modifier can roll. Value is in percent (0.01 means 1%, 0.1 means 10%, ...) [range: 0.0 ~ 1.0, default: 0.08]
             S:Less_Higher_Bound=0.08
@@ -372,37 +372,37 @@ perks {
             S:Less_Lower_Bound=0.05
 
             # Defines the lower bound an 'more' modifier can roll. Value is in percent (0.01 means 1%, 0.1 means 10%, ...) [range: 0.0 ~ 1.0, default: 0.08]
-            S:More_Higher_Bound=0.08
+            S:More_Higher_Bound=0.1
 
             # Defines the lower bound an 'more' modifier can roll. Value is in percent (0.01 means 1%, 0.1 means 10%, ...) [range: 0.0 ~ 1.0, default: 0.05]
-            S:More_Lower_Bound=0.05
+            S:More_Lower_Bound=0.08
         }
 
     }
 
     root_aevitas {
         # Sets the exp multiplier exp gained from this root-perk are multiplied by. (So higher multiplier -> more exp) [range: 0.0 ~ 1024.0, default: 1.0]
-        S:Exp_Multiplier=1.0
+        S:Exp_Multiplier=1.7
     }
 
     root_vicio {
         # Sets the exp multiplier exp gained from this root-perk are multiplied by. (So higher multiplier -> more exp) [range: 0.0 ~ 1024.0, default: 1.0]
-        S:Exp_Multiplier=0.9
+        S:Exp_Multiplier=0.1
     }
 
     root_armara {
         # Sets the exp multiplier exp gained from this root-perk are multiplied by. (So higher multiplier -> more exp) [range: 0.0 ~ 1024.0, default: 1.0]
-        S:Exp_Multiplier=1.5
+        S:Exp_Multiplier=1
     }
 
     root_discidia {
         # Sets the exp multiplier exp gained from this root-perk are multiplied by. (So higher multiplier -> more exp) [range: 0.0 ~ 1024.0, default: 1.0]
-        S:Exp_Multiplier=2.0
+        S:Exp_Multiplier=7
     }
 
     root_evorsio {
         # Sets the exp multiplier exp gained from this root-perk are multiplied by. (So higher multiplier -> more exp) [range: 0.0 ~ 1024.0, default: 1.0]
-        S:Exp_Multiplier=1.2
+        S:Exp_Multiplier=11
     }
 
     key_stone_enrichment {
@@ -644,7 +644,7 @@ ritual_effects {
         S:mineralisPotencyMultiplier=1.0
 
         # Defines the radius (in blocks) in which the ritual will search for cleanStone to generate ores into. [range: 1 ~ 32, default: 8]
-        I:mineralisRange=8
+        I:mineralisRange=16
     }
 
     lucerna {
@@ -698,7 +698,7 @@ ritual_effects {
         S:octansPotencyMultiplier=1.0
 
         # Defines the radius (in blocks) in which the ritual will search for water  [range: 1 ~ 32, default: 12]
-        I:octansRange=12
+        I:octansRange=32
     }
 
     fornax {

--- a/.minecraft/config/battletowers.cfg
+++ b/.minecraft/config/battletowers.cfg
@@ -84,7 +84,7 @@ biomespawnallowed {
     B:cliffs=true
     B:cold_beach=true
     B:coniferous_forest=true
-    B:corrupted_sands=true
+    B:corrupted_sands=false
     B:crag_cliffs=true
     B:deep_ocean=true
     B:desert=true
@@ -114,6 +114,7 @@ biomespawnallowed {
     B:jungle_hills=true
     B:kelp_forest=true
     B:lush_hills=true
+    B:magical_forest=true
     B:mangrove=true
     B:marsh=true
     B:meadow=true

--- a/.minecraft/config/battletowers.cfg
+++ b/.minecraft/config/battletowers.cfg
@@ -173,8 +173,8 @@ chunkproviderallowed {
 
 
 mainoptions {
-    I:"Minimum Distance between 2 BattleTowers"=500
-    I:"Minimum Distance of Battletowers from Spawn"=500
+    I:"Minimum Distance between 2 BattleTowers"=700
+    I:"Minimum Distance of Battletowers from Spawn"=700
     I:"Tower Destroying Enabled"=1
     I:chanceTowerIsUnderGround=20
     B:noGolemExplosions=false

--- a/.minecraft/config/cofh/world/netherendingores.json
+++ b/.minecraft/config/cofh/world/netherendingores.json
@@ -2,6 +2,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"end-iridium": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -31,6 +32,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-platinum": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -60,6 +62,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-emerald": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -89,6 +92,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-diamond": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -118,6 +122,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-lapis": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -147,6 +152,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-gold": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -176,6 +182,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-redstone": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -205,6 +212,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-iron": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -234,6 +242,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-coal": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {
@@ -263,6 +272,7 @@
 	"dependencies": "netherendingores",
 	"populate": {
 		"nether-uranium": {
+			"enabled": "true",
 			"distribution": "uniform",
 			"generator": {
 				"block": {

--- a/.minecraft/config/mekanism.cfg
+++ b/.minecraft/config/mekanism.cfg
@@ -248,7 +248,7 @@ general {
     D:SawdustChancePlank=0.25
 
     # Enable the spawning of baby skeletons. Think baby zombies but skeletons.
-    B:SpawnBabySkeletons=true
+    B:SpawnBabySkeletons=false
 
     # Amount of heat each Boiler heating element produces.
     D:SuperheatingHeatTransfer=10000.0

--- a/.minecraft/config/mysticalagriculture.cfg
+++ b/.minecraft/config/mysticalagriculture.cfg
@@ -1,0 +1,562 @@
+# Configuration file
+
+##########################################################################################################
+# fun stuff
+#--------------------------------------------------------------------------------------------------------#
+# Fun things made with essences. Sometimes.
+##########################################################################################################
+
+"fun stuff" {
+    # Essence Apple buff durations in minutes. [range: 1 ~ 100, default: 2]
+    I:apple_buff_duration=2
+
+    # Should Mystical Crops be plantable via dispensers? [default: true]
+    B:dispenser_planting=true
+
+    # Essence Apples enabled? [default: true]
+    B:essence_apples=true
+
+    # Essence Coal enabled? [default: true]
+    B:essence_coal=true
+
+    # Essence Furnaces enabled? [default: true]
+    B:essence_furnaces=true
+
+    # Should fake players be able to use the watering cans? [default: false]
+    B:fake_player_watering=false
+
+    # Ultimate Furnace enabled? Requires Essence Furnaces be enabled. [default: true]
+    B:ultimate_furnace=true
+
+    # Should the Ultimate Seed Reprocessor be enabled? [default: true]
+    B:ultimate_reprocessor=true
+
+    # Should the essence Watering Cans be enabled? [default: true]
+    B:watering_cans=true
+}
+
+
+##########################################################################################################
+# gear
+#--------------------------------------------------------------------------------------------------------#
+# Settings for the Mystical Agriculture: Gear module.
+##########################################################################################################
+
+gear {
+    # Gear Module enabled? [default: true]
+    B:_gear_module_override=true
+
+    # Should Prudentium+ armor give set bonuses? This does not affect the Supremium Flight option. [default: true]
+    B:set_bonuses=true
+
+    # Wearing a full set of Supremium Armor gives flight. [default: true]
+    B:supremium_flight=true
+}
+
+
+##########################################################################################################
+# seeds
+#--------------------------------------------------------------------------------------------------------#
+# Enable/Disable seeds individually.
+# 0: Disable the seed.
+# 1: Soft-enable the seed. (default)
+# 2: Force-enable the seed.
+##########################################################################################################
+
+seeds {
+    I:abyssalnite_seeds=1
+    I:adamantine_seeds=1
+    I:aluminum_brass_seeds=1
+    I:aluminum_seeds=1
+    I:alumite_seeds=1
+    I:amber_seeds=1
+    I:apatite_seeds=1
+    I:aquamarine_seeds=1
+    I:aquarium_seeds=1
+    I:ardite_seeds=1
+    I:basalt_seeds=1
+    I:basalz_seeds=1
+    I:black_quartz_seeds=1
+    I:blaze_seeds=1
+    I:blitz_seeds=1
+    I:blizz_seeds=1
+    I:blue_topaz_seeds=1
+    I:boron_seeds=1
+    I:brass_seeds=1
+    I:bronze_seeds=1
+    I:certus_quartz_seeds=1
+    I:chicken_seeds=1
+    I:chimerite_seeds=1
+    I:chrome_seeds=1
+    I:coal_seeds=1
+    I:cobalt_seeds=1
+    I:cold_iron_seeds=1
+    I:compressed_iron_seeds=1
+    I:conductive_iron_seeds=1
+    I:constantan_seeds=1
+    I:copper_seeds=1
+    I:coralium_seeds=1
+    I:cow_seeds=1
+    I:creeper_seeds=1
+    I:dark_gem_seeds=1
+    I:dark_steel_seeds=1
+    I:dawnstone_seeds=1
+    I:desh_seeds=1
+    I:diamond_seeds=1
+    I:dilithium_seeds=1
+    I:dirt_seeds=1
+    I:draconium_seeds=1
+    I:dreadium_seeds=1
+    I:dye_seeds=1
+    I:electrical_steel_seeds=1
+    I:electrotine_seeds=1
+    I:electrum_seeds=1
+    I:elementium_seeds=1
+    I:emerald_seeds=1
+    I:end_seeds=1
+    I:end_steel_seeds=1
+    I:ender_amethyst_seeds=1
+    I:ender_biotite_seeds=1
+    I:enderium_seeds=1
+    I:enderman_seeds=1
+    I:energetic_alloy_seeds=1
+    I:experience_seeds=1
+    I:fiery_ingot_seeds=1
+    I:fire_seeds=1
+    I:fluix_seeds=1
+    I:fluxed_electrum_seeds=1
+    I:ghast_seeds=1
+    I:glowstone_ingot_seeds=1
+    I:glowstone_seeds=1
+    I:gold_seeds=1
+    I:grains_of_infinity_seeds=1
+    I:graphite_seeds=1
+    I:guardian_seeds=1
+    I:hop_graphite_seeds=1
+    I:ice_seeds=1
+    I:invar_seeds=1
+    I:iridium_ore_seeds=1
+    I:iridium_seeds=1
+    I:iron_seeds=1
+    I:ironwood_seeds=1
+    I:jade_seeds=1
+    I:knightmetal_seeds=1
+    I:knightslime_seeds=1
+    I:lapis_lazuli_seeds=1
+    I:lead_seeds=1
+    I:limestone_seeds=1
+    I:lithium_seeds=1
+    I:lumium_seeds=1
+    I:magnesium_seeds=1
+    I:malachite_seeds=1
+    I:manasteel_seeds=1
+    I:manyullyn_seeds=1
+    I:marble_seeds=1
+    I:menril_seeds=1
+    I:meteoric_iron_seeds=1
+    I:mithril_seeds=1
+    I:moonstone_seeds=1
+    I:mystical_flower_seeds=1
+    I:nature_seeds=1
+    I:nether_quartz_seeds=1
+    I:nether_seeds=1
+    I:nickel_seeds=1
+    I:obsidian_seeds=1
+    I:octine_seeds=1
+    I:osmium_seeds=1
+    I:peridot_seeds=1
+    I:pig_seeds=1
+    I:platinum_seeds=1
+    I:pulsating_iron_seeds=1
+    I:quartz_enriched_iron_seeds=1
+    I:quicksilver_seeds=1
+    I:rabbit_seeds=1
+    I:redstone_alloy_seeds=1
+    I:redstone_seeds=1
+    I:refined_obsidian_seeds=1
+    I:rock_crystal_seeds=1
+    I:rubber_seeds=1
+    I:ruby_seeds=1
+    I:saltpeter_seeds=1
+    I:sapphire_seeds=1
+    I:sheep_seeds=1
+    I:signalum_seeds=1
+    I:silicon_seeds=1
+    I:silver_seeds=1
+    I:skeleton_seeds=1
+    I:sky_stone_seeds=1
+    I:slate_seeds=1
+    I:slime_seeds=1
+    I:slimy_bone_seeds=1
+    I:soularium_seeds=1
+    I:spider_seeds=1
+    I:star_steel_seeds=1
+    I:starmetal_seeds=1
+    I:steel_seeds=1
+    I:steeleaf_seeds=1
+    I:stone_seeds=1
+    I:sulfur_seeds=1
+    I:sunstone_seeds=1
+    I:syrmorite_seeds=1
+    I:tanzanite_seeds=1
+    I:terrasteel_seeds=1
+    I:thaumium_seeds=1
+    I:thorium_seeds=1
+    I:tin_seeds=1
+    I:titanium_seeds=1
+    I:topaz_seeds=1
+    I:tritanium_seeds=1
+    I:tungsten_seeds=1
+    I:uranium_238_seeds=1
+    I:uranium_seeds=1
+    I:valonite_seeds=1
+    I:vibrant_alloy_seeds=1
+    I:vinteum_seeds=1
+    I:void_metal_seeds=1
+    I:water_seeds=1
+    I:wither_skeleton_seeds=1
+    I:wood_seeds=1
+    I:yellorium_seeds=1
+    I:zinc_seeds=1
+    I:zombie_seeds=1
+}
+
+
+##########################################################################################################
+# settings
+#--------------------------------------------------------------------------------------------------------#
+# Settings for all things Mystical Agriculture.
+##########################################################################################################
+
+settings {
+    # Should you be able to craft mob chunks? [default: true]
+    B:craftable_chunks=true
+
+    # The durability of the basic Infusion Crystal. [range: 1 ~ 25000, default: 1000]
+    I:crystal_durability=1000
+
+    # Amount of Supremium Essence the Ender Dragon should drop when killed. [range: 0 ~ 64, default: 4]
+    I:dragon_supremium=4
+
+    # Percentage chance of a second essence dropping. [range: 0 ~ 100, default: 5]
+    I:essence_chance=5
+
+    # Enable Fertilized Essence? [default: true]
+    B:fertilized_essence=true
+
+    # Percentage chance that a Resource Crop will drop a Fertilized Essence when harvested. [range: 0 ~ 100, default: 5]
+    I:fertilized_essence_chance=5
+
+    # Should the resource essences/seeds be added to the OreDictionary as essenceTier1, seedsTier1, etc.? [default: true]
+    B:generic_ore_dict_essence=true
+
+    # Enable Growth Accelerators? [default: true]
+    B:growth_accelerator=true
+
+    # Amount of seconds between each growth tick attempt. [range: 1 ~ 3600, default: 10]
+    I:growth_accelerator_speed=10
+
+    # Makes the Essence Ingots require 4 essence each instead of 2. [default: false]
+    B:harder_ingots=false
+
+    # Percentage chance for a hostile mob when killed to drop an Inferium Essence. [range: 0 ~ 100, default: 20]
+    I:hostile_drop_chance=20
+
+    # Enable Mystical Fertilizer? [default: true]
+    B:mystical_fertilizer=true
+
+    # Percentage chance for a passive mob when killed to drop an Inferium Essence. [range: 0 ~ 100, default: 20]
+    I:passive_drop_chance=20
+
+    # The durability of the Core Remover. [range: 1 ~ 25000, default: 4]
+    I:remover_durability=4
+
+    # Percentage chance of a second seed dropping. [range: 0 ~ 100, default: 10]
+    I:seed_chance=10
+
+    # Should the Seed Reprocessor be enabled? [default: true]
+    B:seed_reprocessor=true
+
+    # Amount of Supremium Essence the Wither should drop when killed. [range: 0 ~ 64, default: 2]
+    I:wither_supremium=2
+
+    # Enable the Witherproof Block and Glass? [default: true]
+    B:witherproof_blocks=true
+}
+
+
+##########################################################################################################
+# tiers
+#--------------------------------------------------------------------------------------------------------#
+# Set the tiers of each seed. The tier affects the recipe and the tooltip.
+# Tier 1: Inferium
+# Tier 2: Prudentium
+# Tier 3: Intermedium
+# Tier 4: Superium
+# Tier 5: Supremium
+##########################################################################################################
+
+tiers {
+    I:abyssalnite_tier=4
+    I:adamantine_tier=5
+    I:aluminum_brass_tier=2
+    I:aluminum_tier=2
+    I:alumite_tier=4
+    I:amber_tier=4
+    I:apatite_tier=2
+    I:aquamarine_tier=3
+    I:aquarium_tier=3
+    I:ardite_tier=3
+    I:basalt_tier=2
+    I:basalz_tier=3
+    I:black_quartz_tier=3
+    I:blaze_tier=4
+    I:blitz_tier=3
+    I:blizz_tier=3
+    I:blue_topaz_tier=3
+    I:boron_tier=4
+    I:brass_tier=3
+    I:bronze_tier=3
+    I:certus_quartz_tier=3
+    I:chicken_tier=2
+    I:chimerite_tier=3
+    I:chrome_tier=5
+    I:coal_tier=2
+    I:cobalt_tier=4
+    I:cold_iron_tier=3
+    I:compressed_iron_tier=4
+    I:conductive_iron_tier=3
+    I:constantan_tier=4
+    I:copper_tier=2
+    I:coralium_tier=3
+    I:cow_tier=2
+    I:creeper_tier=3
+    I:dark_gem_tier=3
+    I:dark_steel_tier=4
+    I:dawnstone_tier=4
+    I:desh_tier=5
+    I:diamond_tier=5
+    I:dilithium_tier=4
+    I:dirt_tier=1
+    I:draconium_tier=5
+    I:dreadium_tier=5
+    I:dye_tier=2
+    I:electrical_steel_tier=3
+    I:electrotine_tier=3
+    I:electrum_tier=4
+    I:elementium_tier=4
+    I:emerald_tier=5
+    I:end_steel_tier=5
+    I:end_tier=4
+    I:ender_amethyst_tier=5
+    I:ender_biotite_tier=3
+    I:enderium_tier=5
+    I:enderman_tier=4
+    I:energetic_alloy_tier=4
+    I:experience_tier=4
+    I:fiery_ingot_tier=4
+    I:fire_tier=2
+    I:fluix_tier=4
+    I:fluxed_electrum_tier=4
+    I:ghast_tier=4
+    I:glowstone_ingot_tier=4
+    I:glowstone_tier=3
+    I:gold_tier=4
+    I:grains_of_infinity_tier=2
+    I:graphite_tier=3
+    I:guardian_tier=3
+    I:hop_graphite_tier=4
+    I:ice_tier=1
+    I:invar_tier=4
+    I:iridium_ore_tier=5
+    I:iridium_tier=5
+    I:iron_tier=3
+    I:ironwood_tier=3
+    I:jade_tier=4
+    I:knightmetal_tier=4
+    I:knightslime_tier=3
+    I:lapis_lazuli_tier=4
+    I:lead_tier=3
+    I:limestone_tier=2
+    I:lithium_tier=4
+    I:lumium_tier=4
+    I:magnesium_tier=4
+    I:malachite_tier=4
+    I:manasteel_tier=3
+    I:manyullyn_tier=5
+    I:marble_tier=2
+    I:menril_tier=2
+    I:meteoric_iron_tier=4
+    I:mithril_tier=4
+    I:moonstone_tier=5
+    I:mystical_flower_tier=2
+    I:nature_tier=1
+    I:nether_quartz_tier=3
+    I:nether_tier=2
+    I:nickel_tier=4
+    I:obsidian_tier=3
+    I:octine_tier=3
+    I:osmium_tier=4
+    I:peridot_tier=4
+    I:pig_tier=2
+    I:platinum_tier=5
+    I:pulsating_iron_tier=4
+    I:quartz_enriched_iron_tier=3
+    I:quicksilver_tier=3
+    I:rabbit_tier=3
+    I:redstone_alloy_tier=3
+    I:redstone_tier=3
+    I:refined_obsidian_tier=5
+    I:rock_crystal_tier=5
+    I:rubber_tier=2
+    I:ruby_tier=4
+    I:saltpeter_tier=3
+    I:sapphire_tier=4
+    I:sheep_tier=2
+    I:signalum_tier=4
+    I:silicon_tier=2
+    I:silver_tier=3
+    I:skeleton_tier=3
+    I:sky_stone_tier=3
+    I:slate_tier=2
+    I:slime_tier=2
+    I:slimy_bone_tier=2
+    I:soularium_tier=4
+    I:spider_tier=3
+    I:star_steel_tier=4
+    I:starmetal_tier=5
+    I:steel_tier=4
+    I:steeleaf_tier=3
+    I:stone_tier=1
+    I:sulfur_tier=2
+    I:sunstone_tier=5
+    I:syrmorite_tier=3
+    I:tanzanite_tier=4
+    I:terrasteel_tier=5
+    I:thaumium_tier=3
+    I:thorium_tier=4
+    I:tin_tier=3
+    I:titanium_tier=5
+    I:topaz_tier=4
+    I:tritanium_tier=4
+    I:tungsten_tier=5
+    I:uranium_238_tier=5
+    I:uranium_tier=5
+    I:valonite_tier=5
+    I:vibrant_alloy_tier=5
+    I:vinteum_tier=3
+    I:void_metal_tier=4
+    I:water_tier=1
+    I:wither_skeleton_tier=5
+    I:wood_tier=1
+    I:yellorium_tier=5
+    I:zinc_tier=3
+    I:zombie_tier=1
+}
+
+
+##########################################################################################################
+# world
+#--------------------------------------------------------------------------------------------------------#
+# Settings for any World Generation in Mystical Agriculture.
+##########################################################################################################
+
+world {
+    # Maximum Y level End Inferium Ore should spawn. [range: 1 ~ 127, default: 100]
+    I:end_inferium_maxy=100
+
+    # Minimum Y level End Inferium Ore should spawn. [range: 1 ~ 127, default: 10]
+    I:end_inferium_miny=10
+
+    # Amount of End Inferium Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 20]
+    I:end_inferium_veincount=20
+
+    # Size of the End Inferium Ore veins. [range: 0 ~ 100, default: 6]
+    I:end_inferium_veinsize=6
+
+    # Maximum Y level End Prosperity Ore should spawn. [range: 1 ~ 127, default: 100]
+    I:end_prosperity_maxy=100
+
+    # Minimum Y level End Prosperity Ore should spawn. [range: 1 ~ 127, default: 10]
+    I:end_prosperity_miny=10
+
+    # Amount of End Prosperity Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 20]
+    I:end_prosperity_veincount=20
+
+    # Size of the End Prosperity Ore veins. [range: 0 ~ 100, default: 6]
+    I:end_prosperity_veinsize=6
+
+    # Should the end ores generate in the world? [default: true]
+    B:generate_end=false
+
+    # Should the nether ores generate in the world? [default: true]
+    B:generate_nether=true
+
+    # Should the regular ores generate in the world? [default: true]
+    B:generate_regular=false
+
+    # Should Soulstone generate in the nether? [default: true]
+    B:generate_soulstone=true
+
+    # Maximum Y level Inferium Ore should spawn. [range: 1 ~ 255, default: 50]
+    I:inferium_maxy=50
+
+    # Minimum Y level Inferium Ore should spawn. [range: 1 ~ 255, default: 16]
+    I:inferium_miny=16
+
+    # Amount of Inferium Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 16]
+    I:inferium_veincount=16
+
+    # Size of the Inferium Ore veins. [range: 0 ~ 100, default: 6]
+    I:inferium_veinsize=6
+
+    # Maximum Y level Nether Inferium Ore should spawn. [range: 1 ~ 127, default: 100]
+    I:nether_inferium_maxy=100
+
+    # Minimum Y level Nether Inferium Ore should spawn. [range: 1 ~ 127, default: 10]
+    I:nether_inferium_miny=10
+
+    # Amount of Nether Inferium Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 16]
+    I:nether_inferium_veincount=16
+
+    # Size of the Nether Inferium Ore veins. [range: 0 ~ 100, default: 6]
+    I:nether_inferium_veinsize=6
+
+    # Maximum Y level Nether Prosperity Ore should spawn. [range: 1 ~ 127, default: 100]
+    I:nether_prosperity_maxy=100
+
+    # Minimum Y level Nether Prosperity Ore should spawn. [range: 1 ~ 127, default: 10]
+    I:nether_prosperity_miny=10
+
+    # Amount of Nether Prosperity Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 12]
+    I:nether_prosperity_veincount=12
+
+    # Size of the Nether Prosperity Ore veins. [range: 0 ~ 100, default: 6]
+    I:nether_prosperity_veinsize=6
+
+    # Maximum Y level Prosperity Ore should spawn. [range: 1 ~ 255, default: 50]
+    I:prosperity_maxy=50
+
+    # Minimum Y level Prosperity Ore should spawn. [range: 1 ~ 255, default: 16]
+    I:prosperity_miny=16
+
+    # Amount of Prosperity Ore veins to spawn. Higher = more. [range: 0 ~ 1000, default: 12]
+    I:prosperity_veincount=12
+
+    # Size of the Prosperity Ore veins. [range: 0 ~ 100, default: 6]
+    I:prosperity_veinsize=6
+
+    # Maximum Y level Soulstone should spawn. [range: 1 ~ 127, default: 124]
+    I:soulstone_maxy=124
+
+    # Minimum Y level Soulstone should spawn. [range: 1 ~ 127, default: 16]
+    I:soulstone_miny=16
+
+    # Amount of Soulstone veins to spawn. Higher = more. [range: 0 ~ 100, default: 8]
+    I:soulstone_veincount=8
+
+    # Size of the Soulstone veins. [range: 0 ~ 40, default: 40]
+    I:soulstone_veinsize=40
+}
+
+

--- a/.minecraft/config/openblocks.cfg
+++ b/.minecraft/config/openblocks.cfg
@@ -204,7 +204,7 @@ features {
     B:explosiveEnchantment=true
 
     # Is  'Flim-flam' enchantment enabled
-    B:flimFlamEnchantment=true
+    B:flimFlamEnchantment=false
 
     # Should every player get info book on first login
     B:infoBook=true

--- a/.minecraft/script/bruhomium.zs
+++ b/.minecraft/script/bruhomium.zs
@@ -1,0 +1,5 @@
+
+recipes.removeShapeless(<tconstruct:soil> * 8, [<ore:gravel>, <ore:sand>, <ore:gravel>, <ore:sand>, <minecraft:clay>, <ore:sand>, <ore:gravel>, <ore:sand>, <ore:gravel>]);
+recipes.removeShapeless(<tconstruct:soil> * 2, [<minecraft:clay_ball>, <ore:gravel>, <ore:sand>]);
+recipes.addShapeless(<tconstruct:soil> * 4, [<minecraft:clay_ball>, <ore:gravel>, <ore:sand>]);
+recipes.addShapeless(<tconstruct:soil> * 16, [<ore:gravel>, <ore:sand>, <ore:gravel>, <ore:sand>, <minecraft:clay>, <ore:sand>, <ore:gravel>, <ore:sand>, <ore:gravel>]);


### PR DESCRIPTION
Perk changes
Max perk level has increased from 30 to 50
We have changed exp multipliers for following perks
Aevitas: 1.0 to 1.7
Vicio: 1.0 to 0.1
Discidia 1.0 to 7.0
Evorsio 1.0 to 11.0
Armara has stayed at 1.0
I have changed this to make all the skill trees level at same time so everyone would have the freedom to choose whatever start they want without struggling to level up

Ritual changes:
Changed octans ritual range from 16 to 36
This ritual increases fishing capabilities and the range wouldn't affect it much anyway except for quality of life

Gem changes:
Buffed slight chances of getting 3 or 4 stats on the gems
Gems in general feel a little bit underwhelming so increasing their chances of getting more stats should make them a bit more viable to use

that should be about it for all the changes, i will see to buff some capes soon because half of them are underwhelming

- Your local star cultist Dom "Laisolus"

Additional changes:
*Battle towers now have 700 blocks minimum separation.
*removed baby skeleton from existence
*Removed Flim Flam enchantment.
*actually enabled extra nether and end ores
*Moved all MysticalAgriculture ores to the nether
*Stopped battle towers from appearing in the nether
*Added Mak's script to increase the amount of grout crafted.