### PR TITLE
Scaling Health and ores fix

### DIFF
--- a/.minecraft/config/GalaxySpace/core.conf
+++ b/.minecraft/config/GalaxySpace/core.conf
@@ -110,7 +110,7 @@ worldgen {
     B:enableOresGeneration=true
 
     # Enable/Disable Generation Ores on Overworld.
-    B:enableOverworldOres=true
+    B:enableOverworldOres=false
 
     # Enable/Disable 'World Engine' - advanced world generation
     B:enableWorldEngine=true

--- a/.minecraft/config/ice_and_fire.cfg
+++ b/.minecraft/config/ice_and_fire.cfg
@@ -184,7 +184,7 @@ all {
     I:"Dragon Gold Search Length"=30
 
     # Dragon griefing - 2 is no griefing, 1 is breaking weak blocks, 0 is default [range: 0 ~ 2, default: 0]
-    I:"Dragon Griefing"=1
+    I:"Dragon Griefing"=2
 
     # Max dragon health. Health is scaled to this [range: 1 ~ 100000, default: 500]
     I:"Dragon Health"=500

--- a/.minecraft/config/reccomplex.cfg
+++ b/.minecraft/config/reccomplex.cfg
@@ -66,6 +66,42 @@ balancing {
 
     # Dimension Expression that will be checked for every single structure. Use this if you want to blacklist / whitelist specific dimensions that shouldn't have structures. [default: ]
     S:universalDimensionMatcher= !id=24
+!id=144
+!id=66
+!id=69
+!id=131
+!id=20
+!id=-23
+!id=4
+!id=-6
+!id=-11325
+!id=-9999
+!id=-343
+!id=-343800852
+!id=7
+!id=17
+!id=-30
+!id=-1030
+!id=-1007
+!id=-2543
+!id=-2542
+!id=-1010
+!id=-1009
+!id=-29
+!id=-1005
+!id=-2544
+!id=-1008
+!id=-1025
+!id=-31
+!id=-1022
+!id=-1017
+!id=-1015
+!id=-1016
+!id=-1014
+!id=-1024
+!id=-28
+!id=-1018
+!id=-1021
 
     # Transformer preset names that are gonna be applied to every single generating structure. Use this if you need to enforce specific rules (e.g. "don't ever spawn wood blocks" (with a replace transformer). [default: ]
     S:universalTransformerPresets <

--- a/.minecraft/config/roughmobs.cfg
+++ b/.minecraft/config/roughmobs.cfg
@@ -67,7 +67,7 @@ blaze {
     B:blazeFlameTouch=false
 
     # Set to false to prevent blazes from pushing attackers away [default: true]
-    B:blazePushAttackersAway=true
+    B:blazePushAttackersAway=false
 }
 
 

--- a/.minecraft/config/scalinghealth/main.cfg
+++ b/.minecraft/config/scalinghealth/main.cfg
@@ -56,13 +56,13 @@ main {
          >
 
         # Adds extra difficulty per additional nearby player. So area difficulty will be multiplied by: 1 + group_bonus * (players_in_area - 1) [range: -10.0 ~ 10.0, default: 0.05000000074505806]
-        S:"Group Area Bonus"=0.05000000074505806
+        S:"Group Area Bonus"=0.025
 
         # Difficulty added per second is multiplied by this if the player is not moving. [range: -100.0 ~ 100.0, default: 0.699999988079071]
-        S:"Idle Multiplier"=0.699999988079071
+        S:"Idle Multiplier"=0.33
 
         # The amount difficulty changes each second. In Difficult Life, the option was named per tick, but was actually applied each second. Negative numbers will decrease difficulty over time. [range: -10000.0 ~ 10000.0, default: 0.0011573999654501677]
-        S:"Increase Per Second"=0.0011573999654501677
+        S:"Increase Per Second"=0.0008333333
 
         # The difficulty a player loses on death. Negative numbers cause the player to gain difficulty. [range: -10000.0 ~ 10000.0, default: 0.0]
         S:"Lost On Death"=2.0
@@ -79,7 +79,7 @@ main {
         S:"Reset Time"=NONE
 
         # The distance from a newly spawned mob to search for players to determine its difficulty level. Set to 0 for unlimited range. [range: 0 ~ 32767, default: 256]
-        I:"Search Radius"=256
+        I:"Search Radius"=128
 
         # The starting difficulty level for new worlds or players joining for the first time. [range: 0.0 ~ 3.4028234663852886E38, default: 0.0]
         S:"Starting Value"=0.0

--- a/.minecraft/config/scalinghealth/main.cfg
+++ b/.minecraft/config/scalinghealth/main.cfg
@@ -241,16 +241,16 @@ main {
         I:"Heart XP Level Cost"=3
 
         # The maximum number of heart containers that a blight will drop when killed. [range: 0 ~ 64, default: 2]
-        I:"Hearts Dropped by Blight Max"=3
+        I:"Hearts Dropped by Blight Max"=9
 
         # The minimum number of heart containers that a blight will drop when killed. [range: 0 ~ 64, default: 0]
-        I:"Hearts Dropped by Blight Min"=0
+        I:"Hearts Dropped by Blight Min"=1
 
         # The maximum number of heart containers that a boss will drop when killed. [range: 0 ~ 64, default: 6]
-        I:"Hearts Dropped by Boss Max"=5
+        I:"Hearts Dropped by Boss Max"=18
 
         # The minimum number of heart containers that a boss will drop when killed. [range: 0 ~ 64, default: 3]
-        I:"Hearts Dropped by Boss Min"=1
+        I:"Hearts Dropped by Boss Min"=3
 
         # The amount of extra health restored when using a heart container. This applies whether or not hearts increase max health. [range: 0 ~ 2147483647, default: 4]
         I:"Hearts Health Restored"=4


### PR DESCRIPTION
*changed some values to make it so difficulty increases by 1 every 20 minutes.
*Removed galaxy space's overworld ores
*Blacklisted recurrent complex from spawning in most dimensions
*Blights and bosses now drop more heart shards