### PR TITLE
Fix ores on GC planets + DE tweaks

### DIFF
--- a/.minecraft/config/brandon3055/DraconicEvolution.cfg
+++ b/.minecraft/config/brandon3055/DraconicEvolution.cfg
@@ -97,7 +97,7 @@ Misc {
     D:draconicAxeAttackSpeed=-3.2
     D:draconicAxeMineSpeed=18.0
     I:draconicBaseMineAOE=1
-    I:draconicBaseRFCapacity=16000000
+    I:draconicBaseRFCapacity=50000000
 
     # Allows you to adjust the total shield capacity of a full set of Draconic Armor.
     I:draconicBaseShieldCapacity=512
@@ -111,7 +111,7 @@ Misc {
     D:draconicPicMineSpeed=18.0
 
     # Allows you to adjust the amount of RF that Draconic Armor requires to recharge 1 shield point.
-    I:draconicShieldRechargeCost=1000
+    I:draconicShieldRechargeCost=100
 
     # Allows you to adjust how fast Draconic Armor is able to recover entropy.  Value is {this number}% every 5 seconds.
     D:draconicShieldRecovery=4.0
@@ -129,7 +129,7 @@ Misc {
     D:wyvernAxeAttackDMG=25.0
     D:wyvernAxeMineSpeed=12.0
     I:wyvernBaseMineAOE=0
-    I:wyvernBaseRFCapacity=4000000
+    I:wyvernBaseRFCapacity=6000000
 
     # Allows you to adjust the total shield capacity of a full set of Wyvern Armor.
     I:wyvernBaseShieldCapacity=256
@@ -141,7 +141,7 @@ Misc {
     D:wyvernPicMineSpeed=12.0
 
     # Allows you to adjust the amount of RF that Wyvern Armor requires to recharge 1 shield point.
-    I:wyvernShieldRechargeCost=1000
+    I:wyvernShieldRechargeCost=100
 
     # Allows you to adjust how fast Wyvern Armor is able to recover entropy.  Value is {this number}% every 5 seconds.
     D:wyvernShieldRecovery=2.0
@@ -160,13 +160,13 @@ Misc {
 
 Tweaks {
     # Enabling this allows boss souls to drop. Use with caution!
-    B:allowBossSouls=false
+    B:allowBossSouls=true
 
     # Set to false to prevent the bows explosion effect from breaking blocks.
     B:bowBlockDamage=true
 
     # Allows you to tweak the chaos guardians health (will only affect new guardians).
-    I:chaosGuardianHealth=2000
+    I:chaosGuardianHealth=3500
 
     # This allows you to prevent certain items from being placed in the draconium chest using their registry name
     S:chestBlackList <
@@ -273,7 +273,7 @@ Tweaks {
     D:reactorFuelUsageMultiplier=1.0
 
     # Adjusts the energy output multiplier of the reactor.
-    D:reactorOutputMultiplier=3.0
+    D:reactorOutputMultiplier=10.0
     # Mobs have a 1 in {this number} chance to drop a soul when killed with the Reaper enchantment.  Note: This is the base value; higher enchantment levels increase this chance.
     I:soulDropChance=1000
 

--- a/.minecraft/config/cofh/world/00_minecraft.json
+++ b/.minecraft/config/cofh/world/00_minecraft.json
@@ -15,10 +15,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -36,10 +38,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -62,10 +66,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -88,10 +94,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -114,10 +122,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -135,10 +145,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -156,10 +168,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -177,10 +191,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -198,10 +214,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -219,10 +237,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -240,10 +260,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -279,10 +301,12 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -319,10 +343,12 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -359,10 +385,12 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},

--- a/.minecraft/config/cofh/world/01_thermalfoundation_ores.json
+++ b/.minecraft/config/cofh/world/01_thermalfoundation_ores.json
@@ -14,10 +14,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -37,10 +39,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -60,10 +64,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -91,10 +97,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -123,10 +131,12 @@
 			"biomeRestriction": "none",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -153,10 +163,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -176,10 +188,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -204,10 +218,12 @@
 				]
 			},
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -224,10 +240,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		}

--- a/.minecraft/config/cofh/world/02_thermalfoundation_oil.json
+++ b/.minecraft/config/cofh/world/02_thermalfoundation_oil.json
@@ -1,0 +1,1 @@
+#We don't want TF oil spawning, we only want oil to come from IP to make things more difficult

--- a/.minecraft/config/cofh/world/03_thermalfoundation_clathrates.json
+++ b/.minecraft/config/cofh/world/03_thermalfoundation_clathrates.json
@@ -28,10 +28,12 @@
 			"retrogen": "true",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},

--- a/.minecraft/config/cofh/world/04_actuallyadditions_ore.json
+++ b/.minecraft/config/cofh/world/04_actuallyadditions_ore.json
@@ -17,10 +17,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		}

--- a/.minecraft/config/cofh/world/05_immersiveengineering_ore.json
+++ b/.minecraft/config/cofh/world/05_immersiveengineering_ore.json
@@ -17,10 +17,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		}

--- a/.minecraft/config/cofh/world/06_large_veins_ore.json
+++ b/.minecraft/config/cofh/world/06_large_veins_ore.json
@@ -30,10 +30,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -66,10 +68,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -102,10 +106,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -139,10 +145,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -180,10 +188,12 @@
 			"retrogen": false,
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		}

--- a/.minecraft/config/cofh/world/15_thaumcraft_ore.json
+++ b/.minecraft/config/cofh/world/15_thaumcraft_ore.json
@@ -14,10 +14,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		},
@@ -34,10 +36,12 @@
 			"retrogen": "false",
 			"biome": "all",
 			"dimension": {
-				"restriction": "blacklist",
+				"restriction": "whitelist",
 				"value": [
-					-1,
-					1
+					0,
+					24,
+					7,
+					-11325
 				]
 			}
 		}


### PR DESCRIPTION
The reason the DE reactor is bumped up so high is so it can compete with the mekanism fusion reactor
With a good fusion reactor, you can typically pull ~45mil Rf/t out so just wanted to point that out
At most with what we have now (3x multiplier) it is able to safely crank out ~10mil Rf/t
The DE reactor is way more expensive and thus should produce more power